### PR TITLE
Luke/create privileges

### DIFF
--- a/src/main/java/sysc4806/graduateAdmissions/model/Operation.java
+++ b/src/main/java/sysc4806/graduateAdmissions/model/Operation.java
@@ -1,0 +1,22 @@
+package sysc4806.graduateAdmissions.model;
+
+import lombok.Getter;
+
+/**
+ * This enumeration lists possible system operations to be used in the creation of privileges.
+ *
+ * @author luke
+ */
+public enum Operation {
+    CREATE("create"),
+    READ("read"),
+    UPDATE("update"),
+    DELETE("delete");
+
+    @Getter
+    private final String description;
+
+    Operation(String description) {
+        this.description = description;
+    }
+}

--- a/src/main/java/sysc4806/graduateAdmissions/model/Owner.java
+++ b/src/main/java/sysc4806/graduateAdmissions/model/Owner.java
@@ -1,0 +1,24 @@
+package sysc4806.graduateAdmissions.model;
+
+import lombok.Getter;
+
+/**
+ * This enumeration lists possible owners of the targets of an operation.
+ * These are used in the creation of privileges. The owner in a privilege
+ * will specify which targets (applications, interests, etc.) are able to be
+ * modified by a particular role.
+ *
+ * @author luke
+ */
+public enum Owner {
+    SELF("self"),
+    ALL_PROFS("all professors"),
+    ALL_STUDENTS("all students");
+
+    @Getter
+    private final String description;
+
+    Owner(String description) {
+        this.description = description;
+    }
+}

--- a/src/main/java/sysc4806/graduateAdmissions/model/Privilege.java
+++ b/src/main/java/sysc4806/graduateAdmissions/model/Privilege.java
@@ -2,6 +2,7 @@ package sysc4806.graduateAdmissions.model;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.GeneratedValue;
@@ -26,8 +27,9 @@ import javax.persistence.Id;
 public class Privilege {
     @Id
     @GeneratedValue(strategy = GenerationType.AUTO)
+    @EqualsAndHashCode.Exclude
     //the primary key for a privilege
-    private transient long id;
+    private long id;
     //the type of CRUD operation the privilege specified
     private Operation operation;
     //the type of object that an operation is performed on

--- a/src/main/java/sysc4806/graduateAdmissions/model/Privilege.java
+++ b/src/main/java/sysc4806/graduateAdmissions/model/Privilege.java
@@ -1,9 +1,8 @@
 package sysc4806.graduateAdmissions.model;
 
-import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-import lombok.NoArgsConstructor;
 
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
@@ -22,8 +21,7 @@ import javax.persistence.Id;
  * @author luke
  */
 @Data
-@AllArgsConstructor
-@NoArgsConstructor
+@Builder
 public class Privilege {
     //the primary key for a privilege
     @Id

--- a/src/main/java/sysc4806/graduateAdmissions/model/Privilege.java
+++ b/src/main/java/sysc4806/graduateAdmissions/model/Privilege.java
@@ -1,0 +1,37 @@
+package sysc4806.graduateAdmissions.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+
+/**
+ * This class is used to specify privileges for roles. A Role with have a collection
+ * of these objects to determine what it can and cannot do. A Privilege is made up of three
+ * parts: An action (eg. create, delete), a target for that action (eg. application, interest),
+ * and an owner of that target (eg. self, everyone). Combinations of these allow the
+ * specification of many different privileges for roles.
+ *
+ * For example, a student would have privileges for creating and deleting their own applications.
+ * Admin staff would have privileges for creating and deleting any student's application.
+ *
+ * @author luke
+ */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class Privilege {
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    //the primary key for a privilege
+    private transient long id;
+    //the type of CRUD operation the privilege specified
+    private Operation operation;
+    //the type of object that an operation is performed on
+    private Target target;
+    //the owner of the specified target object of the specified operation
+    private Owner owner;
+}

--- a/src/main/java/sysc4806/graduateAdmissions/model/Privilege.java
+++ b/src/main/java/sysc4806/graduateAdmissions/model/Privilege.java
@@ -25,10 +25,10 @@ import javax.persistence.Id;
 @AllArgsConstructor
 @NoArgsConstructor
 public class Privilege {
+    //the primary key for a privilege
     @Id
     @GeneratedValue(strategy = GenerationType.AUTO)
     @EqualsAndHashCode.Exclude
-    //the primary key for a privilege
     private long id;
     //the type of CRUD operation the privilege specified
     private Operation operation;

--- a/src/main/java/sysc4806/graduateAdmissions/model/Target.java
+++ b/src/main/java/sysc4806/graduateAdmissions/model/Target.java
@@ -13,7 +13,8 @@ public enum Target {
     APPLICATION("application"),
     INTEREST("interest"),
     TERM("term"),
-    USER("user");
+    USER("user"),
+    ROLE("role");
 
     @Getter
     private final String description;

--- a/src/main/java/sysc4806/graduateAdmissions/model/Target.java
+++ b/src/main/java/sysc4806/graduateAdmissions/model/Target.java
@@ -1,0 +1,24 @@
+package sysc4806.graduateAdmissions.model;
+
+import lombok.Getter;
+
+/**
+ * This enumeration lists possible targets for operations specified by the
+ * Operation enumeration. These are the types of objects that the operation
+ * would be performed on. These are used in the creation of privileges.
+ *
+ * @author luke
+ */
+public enum Target {
+    APPLICATION("application"),
+    INTEREST("interest"),
+    TERM("term"),
+    USER("user");
+
+    @Getter
+    private final String description;
+
+    Target(String description) {
+        this.description = description;
+    }
+}

--- a/src/test/java/sysc4806/graduateAdmissions/model/OperationTest.java
+++ b/src/test/java/sysc4806/graduateAdmissions/model/OperationTest.java
@@ -1,0 +1,28 @@
+package sysc4806.graduateAdmissions.model;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for the Operation enumeration. These tests check that an enum instance can
+ * be successfully created, and that the descriptions for each enum are correct.
+ *
+ * @author luke
+ */
+class OperationTest {
+    @Test
+    public void createEnumSuccessfully(){
+        Operation operation = Operation.CREATE;
+        assertNotNull(operation);
+        assertSame(operation, Operation.CREATE);
+    }
+
+    @Test
+    public void checkDescriptions(){
+        assertEquals(Operation.CREATE.getDescription(), "create");
+        assertEquals(Operation.READ.getDescription(), "read");
+        assertEquals(Operation.UPDATE.getDescription(), "update");
+        assertEquals(Operation.DELETE.getDescription(), "delete");
+    }
+}

--- a/src/test/java/sysc4806/graduateAdmissions/model/OperationTest.java
+++ b/src/test/java/sysc4806/graduateAdmissions/model/OperationTest.java
@@ -11,6 +11,7 @@ import static org.junit.jupiter.api.Assertions.*;
  * @author luke
  */
 class OperationTest {
+    /**Test that enum assignment works as expected*/
     @Test
     public void createEnumSuccessfully(){
         Operation operation = Operation.CREATE;
@@ -18,6 +19,7 @@ class OperationTest {
         assertSame(operation, Operation.CREATE);
     }
 
+    /**Test that the descriptions on each enum value are as expected*/
     @Test
     public void checkDescriptions(){
         assertEquals(Operation.CREATE.getDescription(), "create");

--- a/src/test/java/sysc4806/graduateAdmissions/model/OwnerTest.java
+++ b/src/test/java/sysc4806/graduateAdmissions/model/OwnerTest.java
@@ -1,0 +1,27 @@
+package sysc4806.graduateAdmissions.model;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for the operation enumeration. These tests check that an enum instance can
+ * be successfully created, and that the descriptions for each enum are correct.
+ *
+ * @author luke
+ */
+class OwnerTest {
+    @Test
+    public void createEnumSuccessfully(){
+        Owner owner = Owner.SELF;
+        assertNotNull(owner);
+        assertSame(owner, Owner.SELF);
+    }
+
+    @Test
+    public void checkDescriptions(){
+        assertEquals(Owner.SELF.getDescription(), "self");
+        assertEquals(Owner.ALL_PROFS.getDescription(), "all professors");
+        assertEquals(Owner.ALL_STUDENTS.getDescription(), "all students");
+    }
+}

--- a/src/test/java/sysc4806/graduateAdmissions/model/OwnerTest.java
+++ b/src/test/java/sysc4806/graduateAdmissions/model/OwnerTest.java
@@ -11,6 +11,7 @@ import static org.junit.jupiter.api.Assertions.*;
  * @author luke
  */
 class OwnerTest {
+    /**Test that enum assignment works as expected*/
     @Test
     public void createEnumSuccessfully(){
         Owner owner = Owner.SELF;
@@ -18,6 +19,7 @@ class OwnerTest {
         assertSame(owner, Owner.SELF);
     }
 
+    /**Test that the descriptions on each enum value are as expected*/
     @Test
     public void checkDescriptions(){
         assertEquals(Owner.SELF.getDescription(), "self");

--- a/src/test/java/sysc4806/graduateAdmissions/model/PrivilegeTest.java
+++ b/src/test/java/sysc4806/graduateAdmissions/model/PrivilegeTest.java
@@ -23,6 +23,7 @@ class PrivilegeTest {
         privilege = Privilege.builder().build();
     }
 
+    /**Test to ensure default values of fields of a Privilege are correct*/
     @Test
     public void testNoArgsConstructor(){
         assertNotNull(privilege);
@@ -32,6 +33,7 @@ class PrivilegeTest {
         assertEquals(0, privilege.getId());
     }
 
+    /**Test to ensure that the all args constructor correctly sets fields*/
     @Test
     public void testArgsConstructor(){
         privilege = new Privilege(ID, operation, target, owner);
@@ -41,6 +43,7 @@ class PrivilegeTest {
         assertEquals(owner, privilege.getOwner());
     }
 
+    /**Test to ensure that the builder correctly sets fields*/
     @Test
     public void testBuilder(){
         privilege = Privilege.builder().id(ID).operation(operation)
@@ -51,30 +54,35 @@ class PrivilegeTest {
         assertEquals(owner, privilege.getOwner());
     }
 
+    /**Test that the setID method correctly sets the id field*/
     @Test
     public void setId(){
         privilege.setId(ID);
         assertEquals(ID, privilege.getId());
     }
 
+    /**Test that the setOperation method correctly sets the operation field*/
     @Test
     public void setOperation(){
         privilege.setOperation(operation);
         assertEquals(operation, privilege.getOperation());
     }
 
+    /**Test that the setTarget method correctly sets the target field*/
     @Test
     public void setTarget(){
         privilege.setTarget(target);
         assertEquals(target, privilege.getTarget());
     }
 
+    /**Test that the setOwner method correctly sets the owner field*/
     @Test
     public void setOwner(){
         privilege.setOwner(owner);
         assertEquals(owner, privilege.getOwner());
     }
 
+    /**Test that the generated toString behaves as expected*/
     @Test
     public void testToString(){
         privilege = new Privilege(ID, operation, target, owner);
@@ -82,6 +90,7 @@ class PrivilegeTest {
                 privilege.toString());
     }
 
+    /**Test that two Privilege objects with identical fields are considered equal*/
     @Test
     public void testEquals(){
         Privilege privilegeA = new Privilege(ID, operation, target, owner);
@@ -89,6 +98,7 @@ class PrivilegeTest {
         assertEquals(privilegeA, privilegeB);
     }
 
+    /**Test that two Privilege objects with all fields equal except their ids are still considered equal*/
     @Test
     public void testEqualsDifferentID(){
         Privilege privilegeA = new Privilege(ID, operation, target, owner);
@@ -96,6 +106,7 @@ class PrivilegeTest {
         assertEquals(privilegeA, privilegeB);
     }
 
+    /**Test that objects with different field values are not considered equal*/
     @Test
     public void testNotEquals(){
         Privilege privilegeA = new Privilege(ID, operation, target, owner);

--- a/src/test/java/sysc4806/graduateAdmissions/model/PrivilegeTest.java
+++ b/src/test/java/sysc4806/graduateAdmissions/model/PrivilegeTest.java
@@ -1,0 +1,88 @@
+package sysc4806.graduateAdmissions.model;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class PrivilegeTest {
+    private Privilege privilege;
+    private long ID = 5;
+    private Operation operation = Operation.CREATE;
+    private Target target = Target.APPLICATION;
+    private Owner owner = Owner.SELF;
+
+    @BeforeEach
+    public void setUp(){
+        privilege = new Privilege();
+    }
+
+    @Test
+    public void testNoArgsConstructor(){
+        assertNotNull(privilege);
+        assertNull(privilege.getOperation());
+        assertNull(privilege.getOwner());
+        assertNull(privilege.getTarget());
+        assertEquals(0, privilege.getId());
+    }
+
+    @Test
+    public void testArgsConstructor(){
+        privilege = new Privilege(ID, operation, target, owner);
+        assertEquals(ID, privilege.getId());
+        assertEquals(operation, privilege.getOperation());
+        assertEquals(target, privilege.getTarget());
+        assertEquals(owner, privilege.getOwner());
+    }
+
+    @Test
+    public void setId(){
+        privilege.setId(ID);
+        assertEquals(ID, privilege.getId());
+    }
+
+    @Test
+    public void setOperation(){
+        privilege.setOperation(operation);
+        assertEquals(operation, privilege.getOperation());
+    }
+
+    @Test
+    public void setTarget(){
+        privilege.setTarget(target);
+        assertEquals(target, privilege.getTarget());
+    }
+
+    @Test
+    public void setOwner(){
+        privilege.setOwner(owner);
+        assertEquals(owner, privilege.getOwner());
+    }
+
+    @Test
+    public void testToString(){
+        privilege = new Privilege(ID, operation, target, owner);
+        assertEquals("Privilege(id=5, operation=CREATE, target=APPLICATION, owner=SELF)",
+                privilege.toString());
+    }
+
+    @Test
+    public void testEquals(){
+        Privilege privilegeA = new Privilege(ID, operation, target, owner);
+        Privilege privilegeB = new Privilege(ID, operation, target, owner);
+        assertEquals(privilegeA, privilegeB);
+    }
+
+    @Test
+    public void testEqualsDifferentID(){
+        Privilege privilegeA = new Privilege(ID, operation, target, owner);
+        Privilege privilegeB = new Privilege(ID + 42, operation, target, owner);
+        assertEquals(privilegeA, privilegeB);
+    }
+
+    @Test
+    public void testNotEquals(){
+        Privilege privilegeA = new Privilege(ID, operation, target, owner);
+        assertNotEquals(privilegeA, privilege);
+    }
+}

--- a/src/test/java/sysc4806/graduateAdmissions/model/PrivilegeTest.java
+++ b/src/test/java/sysc4806/graduateAdmissions/model/PrivilegeTest.java
@@ -5,6 +5,12 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+/**
+ * Tests for the Privilege class. Since we are using lombok to generate the
+ * constructors, getters, setters, etc. they are all explicitly tested here.
+ *
+ * @author luke
+ */
 class PrivilegeTest {
     private Privilege privilege;
     private long ID = 5;

--- a/src/test/java/sysc4806/graduateAdmissions/model/PrivilegeTest.java
+++ b/src/test/java/sysc4806/graduateAdmissions/model/PrivilegeTest.java
@@ -20,7 +20,7 @@ class PrivilegeTest {
 
     @BeforeEach
     public void setUp(){
-        privilege = new Privilege();
+        privilege = Privilege.builder().build();
     }
 
     @Test
@@ -35,6 +35,16 @@ class PrivilegeTest {
     @Test
     public void testArgsConstructor(){
         privilege = new Privilege(ID, operation, target, owner);
+        assertEquals(ID, privilege.getId());
+        assertEquals(operation, privilege.getOperation());
+        assertEquals(target, privilege.getTarget());
+        assertEquals(owner, privilege.getOwner());
+    }
+
+    @Test
+    public void testBuilder(){
+        privilege = Privilege.builder().id(ID).operation(operation)
+                .owner(owner).target(target).build();
         assertEquals(ID, privilege.getId());
         assertEquals(operation, privilege.getOperation());
         assertEquals(target, privilege.getTarget());

--- a/src/test/java/sysc4806/graduateAdmissions/model/TargetTest.java
+++ b/src/test/java/sysc4806/graduateAdmissions/model/TargetTest.java
@@ -1,0 +1,28 @@
+package sysc4806.graduateAdmissions.model;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for the Target enumeration. These tests check that an enum instance can
+ * be successfully created, and that the descriptions for each enum are correct.
+ *
+ * @author luke
+ */
+class TargetTest {
+    @Test
+    public void createEnumSuccessfully(){
+        Target target = Target.APPLICATION;
+        assertNotNull(target);
+        assertSame(target, Target.APPLICATION);
+    }
+
+    @Test
+    public void checkDescriptions(){
+        assertEquals(Target.APPLICATION.getDescription(), "application");
+        assertEquals(Target.INTEREST.getDescription(), "interest");
+        assertEquals(Target.TERM.getDescription(), "term");
+        assertEquals(Target.USER.getDescription(), "user");
+    }
+}

--- a/src/test/java/sysc4806/graduateAdmissions/model/TargetTest.java
+++ b/src/test/java/sysc4806/graduateAdmissions/model/TargetTest.java
@@ -11,6 +11,7 @@ import static org.junit.jupiter.api.Assertions.*;
  * @author luke
  */
 class TargetTest {
+    /**Test that enum assignment works as expected*/
     @Test
     public void createEnumSuccessfully(){
         Target target = Target.APPLICATION;
@@ -18,6 +19,7 @@ class TargetTest {
         assertSame(target, Target.APPLICATION);
     }
 
+    /**Test that the descriptions on each enum value are as expected*/
     @Test
     public void checkDescriptions(){
         assertEquals(Target.APPLICATION.getDescription(), "application");

--- a/src/test/java/sysc4806/graduateAdmissions/model/TargetTest.java
+++ b/src/test/java/sysc4806/graduateAdmissions/model/TargetTest.java
@@ -24,5 +24,6 @@ class TargetTest {
         assertEquals(Target.INTEREST.getDescription(), "interest");
         assertEquals(Target.TERM.getDescription(), "term");
         assertEquals(Target.USER.getDescription(), "user");
+        assertEquals(Target.ROLE.getDescription(), "role");
     }
 }


### PR DESCRIPTION
This pull request implements the Privilege object that will be used for specifying what a particular user can do in the system, as specified by issue #5. This object has three fields that define the privilege: a type of operation that can be performed (eg. create, read), a target entity for that operation (eg. Application, Interest), and a specification of who owns the target entity that the operation can be performed on (eg. self only, all). 

These three items can be combined in different ways to get different privileges. For example, students should only be able to create, read and delete their own applications, while admin staff should be able to read any applications.

This pull request can also be used by others to see how some of the annotations in Lombok can be used to reduce a lot of code to write.

The reviewers selected are the only collaborators of the project at the time of making this pull request. When others join the repository they are welcome to review this as well!