### PR TITLE
Luke/create interest

### DIFF
--- a/src/main/java/sysc4806/graduateAdmissions/model/Department.java
+++ b/src/main/java/sysc4806/graduateAdmissions/model/Department.java
@@ -1,0 +1,26 @@
+package sysc4806.graduateAdmissions.model;
+
+import lombok.Getter;
+
+/**
+ * This enumeration lists possible departments in the system.
+ * The list is not exhaustive of all departments in Carleton, since
+ * for the purposes of this project we only need a few to show the
+ * functionality.
+ *
+ * @author luke
+ */
+public enum Department {
+    SYSC("systems and computer engineering"),
+    ELEC("electrical engineering"),
+    AERO("aerospace engineering"),
+    SREE("sustainable and renewable energy engineering"),
+    MAAE("mechanical engineering");
+
+    @Getter
+    private final String description;
+
+    Department(String description) {
+        this.description = description;
+    }
+}

--- a/src/main/java/sysc4806/graduateAdmissions/model/Interest.java
+++ b/src/main/java/sysc4806/graduateAdmissions/model/Interest.java
@@ -1,0 +1,33 @@
+package sysc4806.graduateAdmissions.model;
+
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+
+/**
+ * This class represents an interest area for a user. This is used to match
+ * profs to students for consideration of their graduate application. An
+ * interest has a keyword, which describes the interest, and a department,
+ * since similar keywords may mean things in different contexts
+ *
+ * @author luke
+ */
+@Data
+@Builder
+@Entity
+public class Interest {
+    //the primary key
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    @EqualsAndHashCode.Exclude
+    private long id;
+    //the department for interest context
+    private Department department;
+    //the keyword which defines the interest
+    private String keyword;
+}

--- a/src/test/java/sysc4806/graduateAdmissions/model/DepartmentTest.java
+++ b/src/test/java/sysc4806/graduateAdmissions/model/DepartmentTest.java
@@ -1,0 +1,31 @@
+package sysc4806.graduateAdmissions.model;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for the Department enumeration. These tests check that an enum instance can
+ * be successfully created, and that the descriptions for each enum are correct.
+ *
+ * @author luke
+ */
+class DepartmentTest {
+    /**Test that enum assignment works as expected*/
+    @Test
+    public void createEnumSuccessfully(){
+        Department department = Department.SYSC;
+        assertNotNull(department);
+        assertSame(department, Department.SYSC);
+    }
+
+    /**Test that the descriptions on each enum value are as expected*/
+    @Test
+    public void checkDescriptions(){
+        assertEquals(Department.SYSC.getDescription(), "systems and computer engineering");
+        assertEquals(Department.SREE.getDescription(), "sustainable and renewable energy engineering");
+        assertEquals(Department.MAAE.getDescription(), "mechanical engineering");
+        assertEquals(Department.AERO.getDescription(), "aerospace engineering");
+        assertEquals(Department.ELEC.getDescription(), "electrical engineering");
+    }
+}

--- a/src/test/java/sysc4806/graduateAdmissions/model/InterestTest.java
+++ b/src/test/java/sysc4806/graduateAdmissions/model/InterestTest.java
@@ -1,0 +1,104 @@
+package sysc4806.graduateAdmissions.model;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for the Interest class. Since we are using lombok to generate the
+ * constructors, getters, setters, etc. they are all explicitly tested here.
+ *
+ * @author luke
+ */
+class InterestTest {
+    private Interest interest;
+    private long ID = 5;
+    private Department department = Department.SYSC;
+    private String keyword = "web dev";
+
+    @BeforeEach
+    public void setUp(){
+        interest = Interest.builder().build();
+    }
+
+    /**Test to ensure default values of fields of an Interest are correct*/
+    @Test
+    public void testNoArgsConstructor(){
+        assertNotNull(interest);
+        assertNull(interest.getDepartment());
+        assertNull(interest.getKeyword());
+        assertEquals(0, interest.getId());
+    }
+
+    /**Test to ensure that the all args constructor correctly sets fields*/
+    @Test
+    public void testArgsConstructor(){
+        interest = new Interest(ID, department, keyword);
+        assertEquals(ID, interest.getId());
+        assertEquals(department, interest.getDepartment());
+        assertEquals(keyword, interest.getKeyword());
+    }
+
+    /**Test to ensure that the builder correctly sets fields*/
+    @Test
+    public void testBuilder(){
+        interest = Interest.builder().id(ID).department(department)
+                .keyword(keyword).build();
+        assertEquals(ID, interest.getId());
+        assertEquals(department, interest.getDepartment());
+        assertEquals(keyword, interest.getKeyword());
+    }
+
+    /**Test that the setID method correctly sets the id field*/
+    @Test
+    public void setId(){
+        interest.setId(ID);
+        assertEquals(ID, interest.getId());
+    }
+
+    /**Test that the setDepartment method correctly sets the department field*/
+    @Test
+    public void setDepartment(){
+        interest.setDepartment(department);
+        assertEquals(department, interest.getDepartment());
+    }
+
+    /**Test that the setKeyword method correctly sets the keyword field*/
+    @Test
+    public void setKeyword(){
+        interest.setKeyword(keyword);
+        assertEquals(keyword, interest.getKeyword());
+    }
+
+    /**Test that the generated toString behaves as expected*/
+    @Test
+    public void testToString(){
+        interest = new Interest(ID, department, keyword);
+        assertEquals("Interest(id=5, department=SYSC, keyword=web dev)",
+                interest.toString());
+    }
+
+    /**Test that two Privilege objects with identical fields are considered equal*/
+    @Test
+    public void testEquals(){
+        Interest interest1 = new Interest(ID, department, keyword);
+        Interest interest2 = new Interest(ID, department, keyword);
+        assertEquals(interest1, interest2);
+    }
+
+    /**Test that two Privilege objects with all fields equal except their ids are still considered equal*/
+    @Test
+    public void testEqualsDifferentID(){
+        Interest interest1 = new Interest(ID, department, keyword);
+        Interest interest2 = new Interest(ID + 42, department, keyword);
+        assertEquals(interest1, interest2);
+    }
+
+    /**Test that objects with different field values are not considered equal*/
+    @Test
+    public void testNotEquals(){
+        Interest interest1 = new Interest(ID, department, keyword);
+        assertNotEquals(interest1, interest);
+    }
+}


### PR DESCRIPTION
This pull request is for issue #6, creating the interest class. The interest class has a keyword that describes the interest, and a department, since different departments might use the same word to describe different things.

The department is an enum, we can add more departments to the list if necessary, but since we only need a few to show off the system works, the departments included are just five engineering departments.