### PR TITLE
move toJson method from controller test to utility class

### DIFF
--- a/src/main/java/sysc4806/graduateAdmissions/utilities/Utility.java
+++ b/src/main/java/sysc4806/graduateAdmissions/utilities/Utility.java
@@ -1,0 +1,28 @@
+package sysc4806.graduateAdmissions.utilities;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
+import com.fasterxml.jackson.databind.SerializationFeature;
+
+/**
+ * class for utility functions that are useful for a number of
+ * parts of the system, or useful for several test classes
+ *
+ * @author luke
+ */
+public class Utility {
+    /**
+     * helper method to convert objects into JSON format
+     *
+     * @param o the object to convert to JSON format
+     * @return a string contain the JSON for Object o
+     * @throws JsonProcessingException when JSON writing fails
+     */
+    public static String toJson(Object o) throws JsonProcessingException {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.configure(SerializationFeature.WRAP_ROOT_VALUE, false);
+        ObjectWriter ow = mapper.writer().withDefaultPrettyPrinter();
+        return ow.writeValueAsString(o);
+    }
+}

--- a/src/test/java/sysc4806/graduateAdmissions/controller/InterestControllerTest.java
+++ b/src/test/java/sysc4806/graduateAdmissions/controller/InterestControllerTest.java
@@ -1,9 +1,5 @@
 package sysc4806.graduateAdmissions.controller;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.ObjectWriter;
-import com.fasterxml.jackson.databind.SerializationFeature;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -29,6 +25,7 @@ import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static sysc4806.graduateAdmissions.utilities.Utility.toJson;
 
 /**
  * Tests for the InterestController using MockMVC and a mocked InterestRepository
@@ -65,20 +62,6 @@ class InterestControllerTest {
             when(repo.findById((long) i)).thenReturn(Optional.of(interests.get(i)));
             doNothing().when(repo).deleteById((long) i);
         }
-    }
-
-    /**
-     * helper method to convert objects into JSON format
-     *
-     * @param o the object to convert to JSON format
-     * @return a string contain the JSON for Object o
-     * @throws JsonProcessingException when JSON writing fails
-     */
-    private String toJson(Object o) throws JsonProcessingException {
-        ObjectMapper mapper = new ObjectMapper();
-        mapper.configure(SerializationFeature.WRAP_ROOT_VALUE, false);
-        ObjectWriter ow = mapper.writer().withDefaultPrettyPrinter();
-        return ow.writeValueAsString(o);
     }
 
     /**Test the retrieval of all interests*/

--- a/src/test/java/sysc4806/graduateAdmissions/utilities/UtilityTest.java
+++ b/src/test/java/sysc4806/graduateAdmissions/utilities/UtilityTest.java
@@ -1,0 +1,30 @@
+package sysc4806.graduateAdmissions.utilities;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.junit.jupiter.api.Test;
+import sysc4806.graduateAdmissions.model.Department;
+import sysc4806.graduateAdmissions.model.Interest;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for the functions in the utility class
+ *
+ * @author luke
+ *
+ */
+class UtilityTest {
+
+    @Test
+    void toJson() throws JsonProcessingException {
+        Interest interest = Interest.builder().id(42)
+                .department(Department.SYSC).keyword("spring").build();
+
+        assertEquals(Utility.toJson(interest),
+                "{" + System.lineSeparator() +
+                "  \"id\" : 42," + System.lineSeparator() +
+                "  \"department\" : \"SYSC\"," + System.lineSeparator() +
+                "  \"keyword\" : \"spring\"" + System.lineSeparator() +
+                "}");
+    }
+}


### PR DESCRIPTION
As @CameronRushton mentioned previously, one of the helper methods that I wrote for the InterestControllerTest would be helpful to use in the other controller tests. This pull request moves that helper method into a utilities object so that it can be used by other tests as well