### PR TITLE
replace local variables in Interest and Utility with var and val

### DIFF
--- a/src/main/java/sysc4806/graduateAdmissions/controller/InterestController.java
+++ b/src/main/java/sysc4806/graduateAdmissions/controller/InterestController.java
@@ -1,5 +1,6 @@
 package sysc4806.graduateAdmissions.controller;
 
+import lombok.val;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
@@ -69,7 +70,7 @@ public class InterestController {
     @DeleteMapping("{id}")
     @CrossOrigin
     public ResponseEntity deleteInterest(@PathVariable("id") Long id) {
-        Optional<Interest> interest = repo.findById(id);
+        val interest = repo.findById(id);
         if(interest.isPresent()){
             repo.delete(interest.get());
             return ResponseEntity.ok("interest " + interest.get().getKeyword() +

--- a/src/main/java/sysc4806/graduateAdmissions/utilities/Utility.java
+++ b/src/main/java/sysc4806/graduateAdmissions/utilities/Utility.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
 import com.fasterxml.jackson.databind.SerializationFeature;
+import lombok.var;
 
 /**
  * class for utility functions that are useful for a number of
@@ -20,9 +21,9 @@ public class Utility {
      * @throws JsonProcessingException when JSON writing fails
      */
     public static String toJson(Object o) throws JsonProcessingException {
-        ObjectMapper mapper = new ObjectMapper();
+        var mapper = new ObjectMapper();
         mapper.configure(SerializationFeature.WRAP_ROOT_VALUE, false);
-        ObjectWriter ow = mapper.writer();
+        var ow = mapper.writer();
         return ow.writeValueAsString(o);
     }
 }

--- a/src/test/java/sysc4806/graduateAdmissions/controller/InterestControllerTest.java
+++ b/src/test/java/sysc4806/graduateAdmissions/controller/InterestControllerTest.java
@@ -1,5 +1,6 @@
 package sysc4806.graduateAdmissions.controller;
 
+import lombok.val;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -93,7 +94,7 @@ class InterestControllerTest {
     /**Test the creation of a new Interest object via post*/
     @Test
     public void testPostNewInterest() throws Exception {
-        MvcResult result = mockMvc.perform(post("/interest/create").contentType(APPLICATION_JSON_UTF8)
+        val result = mockMvc.perform(post("/interest/create").contentType(APPLICATION_JSON_UTF8)
                 .content(toJson(
                         Interest.builder().department(Department.MAAE).keyword("wheels").build())))
                 .andExpect(status().isOk())
@@ -104,7 +105,7 @@ class InterestControllerTest {
     /**Test the deletion of an Interest object via delete*/
     @Test
     public void testDeleteInterest() throws Exception {
-        MvcResult result = mockMvc.perform(delete("/interest/{id}", "3"))
+        val result = mockMvc.perform(delete("/interest/{id}", "3"))
                 .andExpect(status().isOk())
                 .andReturn();
         assertTrue(result.getResponse().getContentAsString().contains("interest gears in MAAE successfully deleted"));

--- a/src/test/java/sysc4806/graduateAdmissions/model/InterestTest.java
+++ b/src/test/java/sysc4806/graduateAdmissions/model/InterestTest.java
@@ -1,5 +1,6 @@
 package sysc4806.graduateAdmissions.model;
 
+import lombok.val;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -82,23 +83,23 @@ class InterestTest {
     /**Test that two Privilege objects with identical fields are considered equal*/
     @Test
     public void testEquals(){
-        Interest interest1 = new Interest(ID, department, keyword);
-        Interest interest2 = new Interest(ID, department, keyword);
+        val interest1 = new Interest(ID, department, keyword);
+        val interest2 = new Interest(ID, department, keyword);
         assertEquals(interest1, interest2);
     }
 
     /**Test that two Privilege objects with all fields equal except their ids are still considered equal*/
     @Test
     public void testEqualsDifferentID(){
-        Interest interest1 = new Interest(ID, department, keyword);
-        Interest interest2 = new Interest(ID + 42, department, keyword);
+        val interest1 = new Interest(ID, department, keyword);
+        val interest2 = new Interest(ID + 42, department, keyword);
         assertEquals(interest1, interest2);
     }
 
     /**Test that objects with different field values are not considered equal*/
     @Test
     public void testNotEquals(){
-        Interest interest1 = new Interest(ID, department, keyword);
+        val interest1 = new Interest(ID, department, keyword);
         assertNotEquals(interest1, interest);
     }
 }

--- a/src/test/java/sysc4806/graduateAdmissions/utilities/UtilityTest.java
+++ b/src/test/java/sysc4806/graduateAdmissions/utilities/UtilityTest.java
@@ -1,6 +1,7 @@
 package sysc4806.graduateAdmissions.utilities;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import lombok.val;
 import org.junit.jupiter.api.Test;
 import sysc4806.graduateAdmissions.model.Department;
 import sysc4806.graduateAdmissions.model.Interest;
@@ -17,7 +18,7 @@ class UtilityTest {
 
     @Test
     void toJson() throws JsonProcessingException {
-        Interest interest = Interest.builder().id(42)
+        val interest = Interest.builder().id(42)
                 .department(Department.SYSC).keyword("spring").build();
 
         assertEquals(Utility.toJson(interest),


### PR DESCRIPTION
The prupose of this pull request is to show how we can use "var" and "val" from lombok in our project, so that we can include those for discussion in out presentation. 

Essentially these help you define local variables for your methods without needed to give the type of the variable. "var" is local variable whereas "val" is for a final local variable (ie. constant). Lombok infers the type of the the variable from what you assign the var/val. Unfortuantely it seems that only local variables in methods can use this; it does not work with object fields.

the interest and utility classes are changed in this pull request to show how they can be used.