### PR TITLE
check login against back-end DB

### DIFF
--- a/src/main/java/sysc4806/graduateAdmissions/controller/InvalidLoginException.java
+++ b/src/main/java/sysc4806/graduateAdmissions/controller/InvalidLoginException.java
@@ -1,0 +1,12 @@
+package sysc4806.graduateAdmissions.controller;
+
+/**
+ * an exception to throw when login does not occur correctly
+ *
+ * @author luke
+ */
+public class InvalidLoginException extends Exception {
+    public InvalidLoginException(String s) {
+        super(s);
+    }
+}

--- a/src/main/java/sysc4806/graduateAdmissions/controller/SessionController.java
+++ b/src/main/java/sysc4806/graduateAdmissions/controller/SessionController.java
@@ -75,7 +75,7 @@ public class SessionController {
                 val user = isValidUserEmail(payload.getEmail());
                 //TODO: create a session in backend and give session cookie to frontend with response
                 log.info(payload.getEmail() + " signing in");
-                return new ResponseEntity<>("Login success", HttpStatus.OK);
+                return new ResponseEntity<>(user.getRole().getRoleName(), HttpStatus.OK);
             } catch (InvalidLoginException e) {
                 log.info(payload.getEmail() + " is not a valid email in the user database");
                 return new ResponseEntity<>("Login failed: " + e.getMessage(), HttpStatus.UNAUTHORIZED);

--- a/src/main/java/sysc4806/graduateAdmissions/controller/SessionController.java
+++ b/src/main/java/sysc4806/graduateAdmissions/controller/SessionController.java
@@ -8,17 +8,18 @@ import com.google.api.client.json.JsonFactory;
 import com.google.api.client.json.jackson2.JacksonFactory;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
-import lombok.var;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import sysc4806.graduateAdmissions.model.User;
+import sysc4806.graduateAdmissions.repositories.UserRepository;
 
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
 
 /**
  * This controller handles the creation and deletion of sessions in the system
@@ -29,6 +30,8 @@ import java.util.HashMap;
 @RequestMapping("/")
 @Slf4j
 public class SessionController {
+    @Autowired
+    private UserRepository userRepository;
     private static final HttpTransport transport = new NetHttpTransport();
     private static final JsonFactory jsonFactory = new JacksonFactory();
     //this is assigned by the google sign in site
@@ -50,7 +53,7 @@ public class SessionController {
         try {
            val idToken = verifier.verify(idTokenString);
            assert(idToken != null);
-           log.info("token " + idTokenString + " validated");
+           log.info("token " + idTokenString + " for " + idToken.getPayload().getEmail() + " validated");
            return idToken.getPayload();
         } catch(Exception | AssertionError  e) {
             log.info("token " + idTokenString + " is invalid");
@@ -65,13 +68,39 @@ public class SessionController {
      * @return OK if the token is valid, otherwise UNAUTHORIZED
      */
     @PostMapping("login")
-    public ResponseEntity authenticateLogin(@RequestBody String loginDetails) {
-        var payload = verifyToken(loginDetails);
-        if(payload != null)
-            //TODO: check if the email in the token matches a user and create a session for that user
-            return ResponseEntity.ok("login success");
-        else
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+    public ResponseEntity<String> authenticateLogin(@RequestBody String loginDetails) {
+        val payload = verifyToken(loginDetails);
+        if(payload != null) {
+            try {
+                val user = isValidUserEmail(payload.getEmail());
+                //TODO: create a session in backend and give session cookie to frontend with response
+                log.info(payload.getEmail() + " signing in");
+                return new ResponseEntity<>("Login success", HttpStatus.OK);
+            } catch (InvalidLoginException e) {
+                log.info(payload.getEmail() + " is not a valid email in the user database");
+                return new ResponseEntity<>("Login failed: " + e.getMessage(), HttpStatus.UNAUTHORIZED);
+            }
+        } else {
+            return new ResponseEntity<>("Login failed: 3rd party token invalid", HttpStatus.UNAUTHORIZED);
+        }
+    }
+
+    /**
+     * returns the User entity for a given emil address
+     *
+     * @param email the email address to search for in the system
+     * @return the USer object containing the passed email
+     * @throws InvalidLoginException when there are 0 or multiple users with the email address.
+     */
+    private User isValidUserEmail(String email) throws InvalidLoginException {
+        val usersMatchingEmail = userRepository.findByEmail(email);
+        if(usersMatchingEmail.size() == 1){
+            return usersMatchingEmail.get(0);
+        } else if (usersMatchingEmail.size() > 1){
+            throw new InvalidLoginException("there are multiple accounts with this email!");
+        } else {
+            throw new InvalidLoginException("no account with the specified email address is registered with the system");
+        }
     }
 }
 

--- a/src/main/javascript/src/managers/login-manager.js
+++ b/src/main/javascript/src/managers/login-manager.js
@@ -25,7 +25,6 @@ export class LoginManager extends AbstractManager{
 		let auth2 = gapi.auth2.getAuthInstance();
 		let parent = this;
 		auth2.signOut().then(function () {
-			console.log('User signed out.');
 			parent.aurelia.setRoot(PLATFORM.moduleName('pages/login/login'));
 		});
 	}

--- a/src/main/javascript/src/managers/login-manager.js
+++ b/src/main/javascript/src/managers/login-manager.js
@@ -1,11 +1,12 @@
 import { AbstractManager } from "./abstract-manager";
 import { HttpClient } from "aurelia-fetch-client";
-import { inject } from "aurelia-framework";
+import { inject, Aurelia } from "aurelia-framework";
 
-@inject(HttpClient)
+@inject(HttpClient, Aurelia)
 export class LoginManager extends AbstractManager{
-    constructor(httpClient) {
+    constructor(httpClient, aurelia) {
 		super(httpClient);
+		this.aurelia = aurelia;
 	}
 
     login(token) {
@@ -18,6 +19,14 @@ export class LoginManager extends AbstractManager{
     	};
     	return this.httpClient.fetch(`/login`, options)
     		.then(this.handleError)
-    		.then(this.JSON);
    	}
+
+   	logout() {
+		let auth2 = gapi.auth2.getAuthInstance();
+		let parent = this;
+		auth2.signOut().then(function () {
+			console.log('User signed out.');
+			parent.aurelia.setRoot(PLATFORM.moduleName('pages/login/login'));
+		});
+	}
 }

--- a/src/main/javascript/src/pages/login/login.js
+++ b/src/main/javascript/src/pages/login/login.js
@@ -35,6 +35,7 @@ export class Login {
 		this.loginManager.login(id_token).then(response => {//the handler for login success
 			//load rest of the app
             parent.aurelia.setRoot('app');
+            response.text().then(role => {console.log(role)});
 		}).catch(err => {//the handler for login rejection
 			err.text().then(
 				msg => {

--- a/src/main/javascript/src/pages/login/login.js
+++ b/src/main/javascript/src/pages/login/login.js
@@ -32,9 +32,15 @@ export class Login {
     	//send login token to server to authenticate
 		let id_token = googleUser.getAuthResponse().id_token;
 		let parent = this;
-		this.loginManager.login(id_token).then(response => {
+		this.loginManager.login(id_token).then(response => {//the handler for login success
 			//load rest of the app
             parent.aurelia.setRoot('app');
-		});
+		}).catch(err => {//the handler for login rejection
+			err.text().then(
+				msg => {
+					alert(msg);
+					this.loginManager.logout();
+				})
+		 });
     }
 }

--- a/src/main/javascript/src/resources/components/header/header.html
+++ b/src/main/javascript/src/resources/components/header/header.html
@@ -7,7 +7,7 @@
             </div>
             <div class="navigation">
                 <a repeat.for="route of router.routes" if.bind="route.show" class="item ${route.navModel.isActive? 'active':''} " href.bind="route.route">${route.title}</a>
-            	<a href="#" if.bind="isSignedIn()" click.delegate="onSignOut()">Logout</a>
+            	<a href="#" if.bind="isSignedIn()" click.delegate="logout()">Logout</a>
 			</div>
             
             <!-- <div class="navigation2 ${scroll_position > 90 && screenWidth > 500? 'opacity1':'remove no-display'}">

--- a/src/main/javascript/src/resources/components/header/header.js
+++ b/src/main/javascript/src/resources/components/header/header.js
@@ -1,13 +1,14 @@
 import { inject, bindable, Aurelia } from 'aurelia-framework';
 import { Router } from "aurelia-router"
+import { LoginManager } from 'managers/login-manager';
 
-@inject(Router, Aurelia)
+@inject(Router, Aurelia, LoginManager)
 export class Header {
 
     @bindable scroll_position;
     @bindable scroll_fn;
 
-    constructor(router, aurelia) {
+    constructor(router, aurelia, loginManager) {
         this.router = router;
         this.router.routes.forEach((route, index) => {
             if (route.name === "home") {
@@ -17,7 +18,8 @@ export class Header {
             }
         })
         this.showNavOptions = false;
-        this.aurelia = aurelia
+        this.aurelia = aurelia;
+        this.loginManager = loginManager;
     }
 
     scroll_positionChanged(newValue, oldValue) {
@@ -26,16 +28,11 @@ export class Header {
         }
     }
 
-    onSignOut() {
-		let auth2 = gapi.auth2.getAuthInstance();
-		let parent = this;
-		auth2.signOut().then(function () {
-			console.log('User signed out.');
-			parent.aurelia.setRoot(PLATFORM.moduleName('pages/login/login'));
-		});
-	}
-
 	isSignedIn(){
 		return true;
+	}
+
+	logout(){
+		this.loginManager.logout();
 	}
 }

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -45,9 +45,9 @@ INSERT INTO role_privileges (role_role_name, privileges_id) VALUES
     ('ADMIN', 14);
 
 INSERT INTO user (id, email, first_name, last_name, role_role_name) VALUES
-    (0, 'Peter', 'Parker', 'GAS.student4806@gmail.com', 'STUDENT'),
-    (1, 'Bruce', 'Wayne', 'GAS.prof4806@gmail.com', 'PROFESSOR'),
-    (2, 'Clark', 'Kent', 'GAS.staff4806@gmail.com', 'ADMIN');
+    (0, 'gas.student4806@gmail.com', 'Parker', 'Peter', 'STUDENT'),
+    (1, 'gas.prof4806@gmail.com', 'Wayne', 'Bruce', 'PROFESSOR'),
+    (2, 'gas.staff4806@gmail.com', 'Kent', 'Clark', 'ADMIN');
 
 
 


### PR DESCRIPTION
this pull request adds the first bit of actual security to our program. With this, you can only login with emails that are attached to a user in the database. So the three emails representing different types of users must be used (the credentials are pinned in slack). A couple more points about this PR:

* there are no sessions yet, so you can still make any request to the back end that you want. this is still only front end security. Sessions will come next.
* If an email login fails, there is now a message displayed indicating why (an alert popup box)
* on successful login, the role name is returned to the front end, so we can start making pages specific to different roles!