### PR TITLE
change login to return user that logged in

### DIFF
--- a/src/main/java/sysc4806/graduateAdmissions/controller/SessionController.java
+++ b/src/main/java/sysc4806/graduateAdmissions/controller/SessionController.java
@@ -1,5 +1,6 @@
 package sysc4806.graduateAdmissions.controller;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.api.client.googleapis.auth.oauth2.GoogleIdToken.Payload;
 import com.google.api.client.googleapis.auth.oauth2.GoogleIdTokenVerifier;
 import com.google.api.client.http.HttpTransport;
@@ -20,6 +21,8 @@ import sysc4806.graduateAdmissions.repositories.UserRepository;
 
 import java.util.Arrays;
 import java.util.Collections;
+
+import static sysc4806.graduateAdmissions.utilities.Utility.toJson;
 
 /**
  * This controller handles the creation and deletion of sessions in the system
@@ -75,9 +78,12 @@ public class SessionController {
                 val user = isValidUserEmail(payload.getEmail());
                 //TODO: create a session in backend and give session cookie to frontend with response
                 log.info(payload.getEmail() + " signing in");
-                return new ResponseEntity<>(user.getRole().getRoleName(), HttpStatus.OK);
+                return new ResponseEntity<>(toJson(user), HttpStatus.OK);
             } catch (InvalidLoginException e) {
                 log.info(payload.getEmail() + " is not a valid email in the user database");
+                return new ResponseEntity<>("Login failed: " + e.getMessage(), HttpStatus.UNAUTHORIZED);
+            } catch (JsonProcessingException e){
+                log.info("failed to parse user to json");
                 return new ResponseEntity<>("Login failed: " + e.getMessage(), HttpStatus.UNAUTHORIZED);
             }
         } else {

--- a/src/main/javascript/src/pages/login/login.js
+++ b/src/main/javascript/src/pages/login/login.js
@@ -34,8 +34,12 @@ export class Login {
 		let parent = this;
 		this.loginManager.login(id_token).then(response => {//the handler for login success
 			//load rest of the app
-            parent.aurelia.setRoot('app');
-            response.text().then(role => {console.log(role)});
+            response.json().then(user => {
+            	console.log(user);
+            	console.log(user.role.roleName);
+            	document.cookie = "userID="+user.id+";path=/;";
+            	parent.aurelia.setRoot('app');
+            });
 		}).catch(err => {//the handler for login rejection
 			err.text().then(
 				msg => {

--- a/src/main/javascript/src/resources/components/header/header.js
+++ b/src/main/javascript/src/resources/components/header/header.js
@@ -29,10 +29,13 @@ export class Header {
     }
 
 	isSignedIn(){
-		return true;
+		//if the userID cookie is in the list of cookies, then we are signed in
+		return document.cookie.indexOf('userID=') !== -1;
 	}
 
 	logout(){
+		//delete the cookie by setting it to a date in the past
+		document.cookie = "userID=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;";
 		this.loginManager.logout();
 	}
 }


### PR DESCRIPTION
originally the rolename was returned from the login, which is good since it let you filter stuff by rolename, but when it comes to doing things like adding interests, how do you know which user to add the interest to without a session? You cant really, so this PR changes the login to return the user instead. This still has the rolename in it, but also gives you user info, including the user id which can be used the identify which user to do operations on

the user id is made into a cookie that can be sent to the server so we know who to do the operation on