### PR TITLE
add prof filter for application by status

### DIFF
--- a/src/main/java/sysc4806/graduateAdmissions/controller/StatusController.java
+++ b/src/main/java/sysc4806/graduateAdmissions/controller/StatusController.java
@@ -1,0 +1,28 @@
+package sysc4806.graduateAdmissions.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+import sysc4806.graduateAdmissions.model.Status;
+
+/**
+ * A controller to retrieve the available Statuses in the system
+ *
+ * @author luke
+ *
+ */
+@RestController
+public class StatusController {
+
+    /**
+     * Provides all the available statuses in the system as JSON
+     *
+     * @return JSON containing every status name
+     */
+    @GetMapping("/statuses")
+    public ResponseEntity getStatuses() {
+        return ResponseEntity.status(HttpStatus.OK).body(Status.values());
+    }
+}
+

--- a/src/main/javascript/src/managers/status-manager.js
+++ b/src/main/javascript/src/managers/status-manager.js
@@ -1,0 +1,23 @@
+import { AbstractManager } from "./abstract-manager";
+import { HttpClient } from "aurelia-fetch-client";
+import { inject } from "aurelia-framework";
+
+@inject(HttpClient)
+export class StatusManager extends AbstractManager{
+    constructor(httpClient) {
+		super(httpClient);
+	}
+
+	getStatuses() {
+		var options = {
+			method: "GET",
+			headers: {
+				"Content-Type": "application/json"
+			},
+		};
+
+		return this.httpClient.fetch(`/statuses`, options)
+			.then(this.handleError)
+			.then(this.json);
+	}
+}

--- a/src/main/javascript/src/pages/application/view/view.html
+++ b/src/main/javascript/src/pages/application/view/view.html
@@ -3,6 +3,12 @@
 	<section>
 		<div class="container">
 			<h1>Applications</h1>
+			<p>Filter by:
+				<select value.bind="statusFilter" change.trigger="getApplicationsByFilter()">
+					<option value="all">ALL</option>
+					<option repeat.for="status of statuses" value="${status}">${status}</option>
+				</select>
+			</p>
 			<div if.bind="isStudent">
 				<p>Put your student application display here!</p>
 			</div>
@@ -15,14 +21,15 @@
 							${application.applicant.firstName} ${application.applicant.lastName}: ${application.degree} in ${application.department}
 							<button click.delegate="toggleDetails(application.detailToggleId)">details</button>
 						</p>
+						<p>Status: ${application.status}</p>
 						<p>
 							<button click.delegate="setApplicationStatus(application.id, 'APPROVEDFUNDING')">approve with funding</button>
 							<button click.delegate="setApplicationStatus(application.id, 'APPROVEDNOFUNDING')">approve no funding</button>
 							<button click.delegate="setApplicationStatus(application.id, 'DENIED')">deny</button>
+							<button click.delegate="setApplicationStatus(application.id, 'SUBMITTED')">undo choice</button>
 						</p>
 						<div show.bind="application.showDetails">
 							<p>Term: ${application.term.season} ${application.term.year}</p>
-							<p>Status: ${application.status}</p>
 							<p>GPA: ${application.gpa}</p>
 							<p>Resume: ${application.resumeFileName}</p>
 							<p>Interests:</p>
@@ -41,14 +48,15 @@
 							${application.applicant.firstName} ${application.applicant.lastName}: ${application.degree} in ${application.department}
 							<button click.delegate="toggleDetails(application.detailToggleId)">details</button>
 						</p>
+						<p>Status: ${application.status}</p>
 						<p>
 							<button click.delegate="setApplicationStatus(application.id, 'APPROVEDFUNDING')">approve with funding</button>
 							<button click.delegate="setApplicationStatus(application.id, 'APPROVEDNOFUNDING')">approve no funding</button>
 							<button click.delegate="setApplicationStatus(application.id, 'DENIED')">deny</button>
+							<button click.delegate="setApplicationStatus(application.id, 'SUBMITTED')">undo choice</button>
 						</p>
 						<div show.bind="application.showDetails">
 							<p>Term: ${application.term.season} ${application.term.year}</p>
-							<p>Status: ${application.status}</p>
 							<p>GPA: ${application.gpa}</p>
 							<p>Resume: ${application.resumeFileName}</p>
 							<p>Interests:</p>


### PR DESCRIPTION
this PR is to implement some features as suggested by Cameron in #112. This adds the ability for the prof application page to filter by status on applications, and moves the status out of the "details" expansion so you can see that clicking on the buttons does something. I also added an "undo" button to set the application status back to "submitted"